### PR TITLE
full text search is not working with values like `val:*`

### DIFF
--- a/__tests__/__snapshots__/fulltext.test.js.snap
+++ b/__tests__/__snapshots__/fulltext.test.js.snap
@@ -1789,6 +1789,1188 @@ type UpdateJobPayload {
 }
 `;
 
+exports[`search with :* works 1`] = `
+"""All input for the create \`Job\` mutation."""
+input CreateJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Job\` to be created by this mutation."""
+  job: JobInput!
+}
+
+"""The output of our create \`Job\` mutation."""
+type CreateJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Job\` that was created by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the \`deleteJobById\` mutation."""
+input DeleteJobByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteJob\` mutation."""
+input DeleteJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Job\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Job\` mutation."""
+type DeleteJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedJobId: ID
+
+  """The \`Job\` that was deleted by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+scalar FullText
+
+"""
+A filter to be used against FullText fields. All fields are combined with a logical ‘and.’
+"""
+input FullTextFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: FullText
+
+  """Equal to the specified value."""
+  equalTo: FullText
+
+  """Included in the specified list."""
+  in: [FullText!]
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Performs a full text search on the field."""
+  matches: String
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: FullText
+
+  """Not equal to the specified value."""
+  notEqualTo: FullText
+
+  """Not included in the specified list."""
+  notIn: [FullText!]
+}
+
+"""
+A filter to be used against Int fields. All fields are combined with a logical ‘and.’
+"""
+input IntFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Int
+
+  """Equal to the specified value."""
+  equalTo: Int
+
+  """Greater than the specified value."""
+  greaterThan: Int
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Int
+
+  """Included in the specified list."""
+  in: [Int!]
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Less than the specified value."""
+  lessThan: Int
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Int
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Int
+
+  """Not equal to the specified value."""
+  notEqualTo: Int
+
+  """Not included in the specified list."""
+  notIn: [Int!]
+}
+
+type Job implements Node {
+  fullText: FullText
+
+  """Full-text search ranking when filtered by \`fullText\`."""
+  fullTextRank: Float
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against \`Job\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input JobCondition {
+  """Checks for equality with the object’s \`fullText\` field."""
+  fullText: FullText
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+}
+
+"""
+A filter to be used against \`Job\` object types. All fields are combined with a logical ‘and.’
+"""
+input JobFilter {
+  """Checks for all expressions in this list."""
+  and: [JobFilter!]
+
+  """Filter by the object’s \`fullText\` field."""
+  fullText: FullTextFilter
+
+  """Filter by the object’s \`id\` field."""
+  id: IntFilter
+
+  """Filter by the object’s \`name\` field."""
+  name: StringFilter
+
+  """Negates the expression."""
+  not: JobFilter
+
+  """Checks for any expressions in this list."""
+  or: [JobFilter!]
+}
+
+"""An input for mutations affecting \`Job\`"""
+input JobInput {
+  fullText: FullText
+  id: Int
+  name: String!
+}
+
+"""Represents an update to a \`Job\`. Fields that are set will be updated."""
+input JobPatch {
+  fullText: FullText
+  id: Int
+  name: String
+}
+
+"""A connection to a list of \`Job\` values."""
+type JobsConnection {
+  """
+  A list of edges which contains the \`Job\` and cursor to aid in pagination.
+  """
+  edges: [JobsEdge]!
+
+  """A list of \`Job\` objects."""
+  nodes: [Job]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Job\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Job\` edge in the connection."""
+type JobsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Job\` at the end of the edge."""
+  node: Job
+}
+
+"""Methods to use when ordering \`Job\`."""
+enum JobsOrderBy {
+  FULL_TEXT_ASC
+  FULL_TEXT_DESC
+  FULL_TEXT_RANK_ASC
+  FULL_TEXT_RANK_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`Job\`."""
+  createJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateJobInput!
+  ): CreateJobPayload
+
+  """Deletes a single \`Job\` using its globally unique id."""
+  deleteJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteJobInput!
+  ): DeleteJobPayload
+
+  """Deletes a single \`Job\` using a unique key."""
+  deleteJobById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteJobByIdInput!
+  ): DeleteJobPayload
+
+  """Updates a single \`Job\` using its globally unique id and a patch."""
+  updateJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateJobInput!
+  ): UpdateJobPayload
+
+  """Updates a single \`Job\` using a unique key and a patch."""
+  updateJobById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateJobByIdInput!
+  ): UpdateJobPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Job\`."""
+  allJobs(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: JobCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: JobFilter
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): JobsConnection
+
+  """Reads a single \`Job\` using its globally unique \`ID\`."""
+  job(
+    """The globally unique \`ID\` to be used in selecting a single \`Job\`."""
+    nodeId: ID!
+  ): Job
+
+  """Get a single \`Job\`."""
+  jobById(id: Int!): Job
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+}
+
+"""
+A filter to be used against String fields. All fields are combined with a logical ‘and.’
+"""
+input StringFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: String
+
+  """
+  Not equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  distinctFromInsensitive: String
+
+  """Ends with the specified string (case-sensitive)."""
+  endsWith: String
+
+  """Ends with the specified string (case-insensitive)."""
+  endsWithInsensitive: String
+
+  """Equal to the specified value."""
+  equalTo: String
+
+  """Equal to the specified value (case-insensitive)."""
+  equalToInsensitive: String
+
+  """Greater than the specified value."""
+  greaterThan: String
+
+  """Greater than the specified value (case-insensitive)."""
+  greaterThanInsensitive: String
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: String
+
+  """Greater than or equal to the specified value (case-insensitive)."""
+  greaterThanOrEqualToInsensitive: String
+
+  """Included in the specified list."""
+  in: [String!]
+
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """Contains the specified string (case-sensitive)."""
+  includes: String
+
+  """Contains the specified string (case-insensitive)."""
+  includesInsensitive: String
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Less than the specified value."""
+  lessThan: String
+
+  """Less than the specified value (case-insensitive)."""
+  lessThanInsensitive: String
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: String
+
+  """Less than or equal to the specified value (case-insensitive)."""
+  lessThanOrEqualToInsensitive: String
+
+  """
+  Matches the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  like: String
+
+  """
+  Matches the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  likeInsensitive: String
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: String
+
+  """
+  Equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  notDistinctFromInsensitive: String
+
+  """Does not end with the specified string (case-sensitive)."""
+  notEndsWith: String
+
+  """Does not end with the specified string (case-insensitive)."""
+  notEndsWithInsensitive: String
+
+  """Not equal to the specified value."""
+  notEqualTo: String
+
+  """Not equal to the specified value (case-insensitive)."""
+  notEqualToInsensitive: String
+
+  """Not included in the specified list."""
+  notIn: [String!]
+
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """Does not contain the specified string (case-sensitive)."""
+  notIncludes: String
+
+  """Does not contain the specified string (case-insensitive)."""
+  notIncludesInsensitive: String
+
+  """
+  Does not match the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLike: String
+
+  """
+  Does not match the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLikeInsensitive: String
+
+  """Does not start with the specified string (case-sensitive)."""
+  notStartsWith: String
+
+  """Does not start with the specified string (case-insensitive)."""
+  notStartsWithInsensitive: String
+
+  """Starts with the specified string (case-sensitive)."""
+  startsWith: String
+
+  """Starts with the specified string (case-insensitive)."""
+  startsWithInsensitive: String
+}
+
+"""All input for the \`updateJobById\` mutation."""
+input UpdateJobByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Job\` being updated.
+  """
+  jobPatch: JobPatch!
+}
+
+"""All input for the \`updateJob\` mutation."""
+input UpdateJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`Job\` being updated.
+  """
+  jobPatch: JobPatch!
+
+  """
+  The globally unique \`ID\` which will identify a single \`Job\` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update \`Job\` mutation."""
+type UpdateJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Job\` that was updated by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+`;
+
+exports[`searching with :* works 1`] = `
+"""All input for the create \`Job\` mutation."""
+input CreateJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`Job\` to be created by this mutation."""
+  job: JobInput!
+}
+
+"""The output of our create \`Job\` mutation."""
+type CreateJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Job\` that was created by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the \`deleteJobById\` mutation."""
+input DeleteJobByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the \`deleteJob\` mutation."""
+input DeleteJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique \`ID\` which will identify a single \`Job\` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete \`Job\` mutation."""
+type DeleteJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedJobId: ID
+
+  """The \`Job\` that was deleted by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+scalar FullText
+
+"""
+A filter to be used against FullText fields. All fields are combined with a logical ‘and.’
+"""
+input FullTextFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: FullText
+
+  """Equal to the specified value."""
+  equalTo: FullText
+
+  """Included in the specified list."""
+  in: [FullText!]
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Performs a full text search on the field."""
+  matches: String
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: FullText
+
+  """Not equal to the specified value."""
+  notEqualTo: FullText
+
+  """Not included in the specified list."""
+  notIn: [FullText!]
+}
+
+"""
+A filter to be used against Int fields. All fields are combined with a logical ‘and.’
+"""
+input IntFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: Int
+
+  """Equal to the specified value."""
+  equalTo: Int
+
+  """Greater than the specified value."""
+  greaterThan: Int
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: Int
+
+  """Included in the specified list."""
+  in: [Int!]
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Less than the specified value."""
+  lessThan: Int
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: Int
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: Int
+
+  """Not equal to the specified value."""
+  notEqualTo: Int
+
+  """Not included in the specified list."""
+  notIn: [Int!]
+}
+
+type Job implements Node {
+  fullText: FullText
+
+  """Full-text search ranking when filtered by \`fullText\`."""
+  fullTextRank: Float
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against \`Job\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input JobCondition {
+  """Checks for equality with the object’s \`fullText\` field."""
+  fullText: FullText
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+}
+
+"""
+A filter to be used against \`Job\` object types. All fields are combined with a logical ‘and.’
+"""
+input JobFilter {
+  """Checks for all expressions in this list."""
+  and: [JobFilter!]
+
+  """Filter by the object’s \`fullText\` field."""
+  fullText: FullTextFilter
+
+  """Filter by the object’s \`id\` field."""
+  id: IntFilter
+
+  """Filter by the object’s \`name\` field."""
+  name: StringFilter
+
+  """Negates the expression."""
+  not: JobFilter
+
+  """Checks for any expressions in this list."""
+  or: [JobFilter!]
+}
+
+"""An input for mutations affecting \`Job\`"""
+input JobInput {
+  fullText: FullText
+  id: Int
+  name: String!
+}
+
+"""Represents an update to a \`Job\`. Fields that are set will be updated."""
+input JobPatch {
+  fullText: FullText
+  id: Int
+  name: String
+}
+
+"""A connection to a list of \`Job\` values."""
+type JobsConnection {
+  """
+  A list of edges which contains the \`Job\` and cursor to aid in pagination.
+  """
+  edges: [JobsEdge]!
+
+  """A list of \`Job\` objects."""
+  nodes: [Job]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Job\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Job\` edge in the connection."""
+type JobsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Job\` at the end of the edge."""
+  node: Job
+}
+
+"""Methods to use when ordering \`Job\`."""
+enum JobsOrderBy {
+  FULL_TEXT_ASC
+  FULL_TEXT_DESC
+  FULL_TEXT_RANK_ASC
+  FULL_TEXT_RANK_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single \`Job\`."""
+  createJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateJobInput!
+  ): CreateJobPayload
+
+  """Deletes a single \`Job\` using its globally unique id."""
+  deleteJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteJobInput!
+  ): DeleteJobPayload
+
+  """Deletes a single \`Job\` using a unique key."""
+  deleteJobById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteJobByIdInput!
+  ): DeleteJobPayload
+
+  """Updates a single \`Job\` using its globally unique id and a patch."""
+  updateJob(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateJobInput!
+  ): UpdateJobPayload
+
+  """Updates a single \`Job\` using a unique key and a patch."""
+  updateJobById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateJobByIdInput!
+  ): UpdateJobPayload
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Job\`."""
+  allJobs(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: JobCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: JobFilter
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): JobsConnection
+
+  """Reads a single \`Job\` using its globally unique \`ID\`."""
+  job(
+    """The globally unique \`ID\` to be used in selecting a single \`Job\`."""
+    nodeId: ID!
+  ): Job
+
+  """Get a single \`Job\`."""
+  jobById(id: Int!): Job
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+}
+
+"""
+A filter to be used against String fields. All fields are combined with a logical ‘and.’
+"""
+input StringFilter {
+  """
+  Not equal to the specified value, treating null like an ordinary value.
+  """
+  distinctFrom: String
+
+  """
+  Not equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  distinctFromInsensitive: String
+
+  """Ends with the specified string (case-sensitive)."""
+  endsWith: String
+
+  """Ends with the specified string (case-insensitive)."""
+  endsWithInsensitive: String
+
+  """Equal to the specified value."""
+  equalTo: String
+
+  """Equal to the specified value (case-insensitive)."""
+  equalToInsensitive: String
+
+  """Greater than the specified value."""
+  greaterThan: String
+
+  """Greater than the specified value (case-insensitive)."""
+  greaterThanInsensitive: String
+
+  """Greater than or equal to the specified value."""
+  greaterThanOrEqualTo: String
+
+  """Greater than or equal to the specified value (case-insensitive)."""
+  greaterThanOrEqualToInsensitive: String
+
+  """Included in the specified list."""
+  in: [String!]
+
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """Contains the specified string (case-sensitive)."""
+  includes: String
+
+  """Contains the specified string (case-insensitive)."""
+  includesInsensitive: String
+
+  """
+  Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
+  """
+  isNull: Boolean
+
+  """Less than the specified value."""
+  lessThan: String
+
+  """Less than the specified value (case-insensitive)."""
+  lessThanInsensitive: String
+
+  """Less than or equal to the specified value."""
+  lessThanOrEqualTo: String
+
+  """Less than or equal to the specified value (case-insensitive)."""
+  lessThanOrEqualToInsensitive: String
+
+  """
+  Matches the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  like: String
+
+  """
+  Matches the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  likeInsensitive: String
+
+  """Equal to the specified value, treating null like an ordinary value."""
+  notDistinctFrom: String
+
+  """
+  Equal to the specified value, treating null like an ordinary value (case-insensitive).
+  """
+  notDistinctFromInsensitive: String
+
+  """Does not end with the specified string (case-sensitive)."""
+  notEndsWith: String
+
+  """Does not end with the specified string (case-insensitive)."""
+  notEndsWithInsensitive: String
+
+  """Not equal to the specified value."""
+  notEqualTo: String
+
+  """Not equal to the specified value (case-insensitive)."""
+  notEqualToInsensitive: String
+
+  """Not included in the specified list."""
+  notIn: [String!]
+
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """Does not contain the specified string (case-sensitive)."""
+  notIncludes: String
+
+  """Does not contain the specified string (case-insensitive)."""
+  notIncludesInsensitive: String
+
+  """
+  Does not match the specified pattern (case-sensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLike: String
+
+  """
+  Does not match the specified pattern (case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.
+  """
+  notLikeInsensitive: String
+
+  """Does not start with the specified string (case-sensitive)."""
+  notStartsWith: String
+
+  """Does not start with the specified string (case-insensitive)."""
+  notStartsWithInsensitive: String
+
+  """Starts with the specified string (case-sensitive)."""
+  startsWith: String
+
+  """Starts with the specified string (case-insensitive)."""
+  startsWithInsensitive: String
+}
+
+"""All input for the \`updateJobById\` mutation."""
+input UpdateJobByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+
+  """
+  An object where the defined keys will be set on the \`Job\` being updated.
+  """
+  jobPatch: JobPatch!
+}
+
+"""All input for the \`updateJob\` mutation."""
+input UpdateJobInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the \`Job\` being updated.
+  """
+  jobPatch: JobPatch!
+
+  """
+  The globally unique \`ID\` which will identify a single \`Job\` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update \`Job\` mutation."""
+type UpdateJobPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`Job\` that was updated by this mutation."""
+  job: Job
+
+  """An edge for our \`Job\`. May be used by Relay 1."""
+  jobEdge(
+    """The method to use when ordering \`Job\`."""
+    orderBy: [JobsOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): JobsEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+`;
+
 exports[`sort by full text rank field works 1`] = `
 """All input for the create \`Job\` mutation."""
 input CreateJobInput {

--- a/package.json
+++ b/package.json
@@ -106,5 +106,6 @@
         }
       ]
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.tsquery.txt
+++ b/src/index.tsquery.txt
@@ -1,0 +1,650 @@
+import { Tsquery } from "pg-tsquery";
+import type {} from "postgraphile";
+import type {} from "postgraphile-plugin-connection-filter";
+import type { SQL } from "postgraphile/pg-sql2";
+import type {
+  PgCodec,
+  PgCodecWithAttributes,
+  PgResource,
+  PgResourceParameter,
+  PgSelectStep,
+  PgSelectSingleStep,
+} from "postgraphile/@dataplan/pg";
+import type { ExecutableStep } from "postgraphile/grafast";
+import { sql } from "postgraphile/pg-sql2";
+import { listOfCodec } from "postgraphile/@dataplan/pg";
+
+declare global {
+  namespace GraphileBuild {
+    interface Inflection {
+      fullTextScalarTypeName(this: Inflection): string;
+      tsqueryScalarTypeName(this: Inflection): string;
+      pgTsvRank(this: Inflection, fieldName: string): string;
+      pgTsvOrderByColumnRankEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        attributeName: string,
+        ascending: boolean,
+      ): string;
+      pgTsvOrderByComputedColumnRankEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        resource: PgResource<any, any, any, PgResourceParameter[], any>,
+        ascending: boolean,
+      ): string;
+    }
+    interface ScopeObjectFieldsField {
+      isPgTSVRankField?: boolean;
+    }
+  }
+  namespace GraphileConfig {
+    interface Plugins {
+      PostGraphileFulltextFilterPlugin: true;
+    }
+
+    interface GatherHelpers {
+      pgFulltextFilter: {
+        getTsvectorCodec(): PgCodec<string, any, any, any, undefined, any, any>;
+        getTsvectorArrayCodec(): PgCodec;
+        getTsqueryCodec(): PgCodec<string, any, any, any, undefined, any, any>;
+        getTsqueryArrayCodec(): PgCodec;
+      };
+    }
+  }
+}
+
+/**
+ * DO NOT DO THIS!
+ */
+type HackedPgSelectStep = PgSelectStep & {
+  __fts_ranks: Record<string, [identifier: SQL, value: SQL]>;
+};
+
+function copyHacks(
+  build: GraphileBuild.Build,
+  $from: HackedPgSelectStep,
+  $to: ExecutableStep,
+) {
+  const $otherSelect = getHackedStep(build, $to);
+  if ($otherSelect) {
+    for (const key in $from.__fts_ranks) {
+      if (!$otherSelect.__fts_ranks[key]) {
+        $otherSelect.__fts_ranks[key] = $from.__fts_ranks[key];
+      } else {
+        console.warn(
+          `Refused to overwrite __fts_ranks[${key}] since it was already set`,
+        );
+      }
+    }
+  } else {
+    console.log(`Couldn't get hacked step`);
+  }
+}
+
+/*
+ * Hacks on hacks on hacks... Don't do this because it breaks
+ * normalized caching - we're only doing it to maintain backwards
+ * compatibility.
+ */
+function getHackedStep(build: GraphileBuild.Build, $someStep: ExecutableStep) {
+  const {
+    dataplanPg: { PgConditionStep, PgSelectStep, PgSelectSingleStep },
+  } = build;
+  let $step = $someStep;
+  while ($step instanceof PgConditionStep) {
+    $step = ($step as any).$parent;
+  }
+  if ($step instanceof PgSelectSingleStep) {
+    $step = $step.getClassStep();
+  }
+  if ($step instanceof PgSelectStep) {
+    const $s = $step as HackedPgSelectStep;
+    if (!$s.__fts_ranks) {
+      $s.__fts_ranks = Object.create(null);
+      $s.setInliningForbidden();
+      const dedupeBefore = $s.deduplicatedWith;
+      $s.deduplicatedWith = function ($otherStep, ...rest) {
+        copyHacks(build, this, $otherStep);
+        return dedupeBefore?.call(this, $otherStep, ...rest);
+      };
+
+      const cloneBefore = $s.clone;
+      $s.clone = function (...args) {
+        const $otherSelect = cloneBefore.apply(this, args);
+        copyHacks(build, this, $otherSelect);
+        return $otherSelect;
+      };
+    }
+    return $s;
+  } else {
+    console.log(`${$step} was not a PgSelectStep... unable to cache rank`);
+    return null;
+  }
+}
+
+const tsquery = new Tsquery();
+
+function isTsvectorCodec(codec: PgCodec) {
+  return (
+    codec.extensions?.pg?.schemaName === "pg_catalog" &&
+    codec.extensions?.pg?.name === "tsvector"
+  );
+}
+
+function isTsQueryCodec(codec: PgCodec) {
+  return (
+    codec.extensions?.pg?.schemaName === "pg_catalog" &&
+    codec.extensions?.pg?.name === "tsquery"
+  );
+}
+
+interface State {
+  tsqueryCodec: PgCodec<string, any, any, any, undefined, any, any> | null;
+  tsqueryArrayCodec: PgCodec | null;
+  tsvectorCodec: PgCodec<string, any, any, any, undefined, any, any> | null;
+  tsvectorArrayCodec: PgCodec | null;
+}
+
+/**
+ * This is a TypeScript constrained identity function to save having to specify
+ * all the generics manually.
+ */
+export function gatherConfig<
+  const TNamespace extends keyof GraphileConfig.GatherHelpers,
+  const TState extends { [key: string]: any } = { [key: string]: any },
+  const TCache extends { [key: string]: any } = { [key: string]: any },
+>(
+  config: GraphileConfig.PluginGatherConfig<TNamespace, TState, TCache>,
+): GraphileConfig.PluginGatherConfig<TNamespace, TState, TCache> {
+  return config;
+}
+
+const PostGraphileFulltextFilterPlugin: GraphileConfig.Plugin = {
+  name: "PostGraphileFulltextFilterPlugin",
+  inflection: {
+    add: {
+      fullTextScalarTypeName() {
+        return "FullText";
+      },
+      tsqueryScalarTypeName() {
+        return "TsQuery";
+      },
+      pgTsvRank(preset, fieldName) {
+        return this.camelCase(`${fieldName}-rank`);
+      },
+      pgTsvOrderByColumnRankEnum(preset, codec, attributeName, ascending) {
+        const columnName = this._attributeName({
+          codec,
+          attributeName,
+          skipRowId: true,
+        });
+        return this.constantCase(
+          `${columnName}_rank_${ascending ? "asc" : "desc"}`,
+        );
+      },
+      pgTsvOrderByComputedColumnRankEnum(preset, codec, resource, ascending) {
+        const columnName = this.computedAttributeField({
+          resource,
+        });
+        return this.constantCase(
+          `${columnName}_rank_${ascending ? "asc" : "desc"}`,
+        );
+      },
+    },
+  },
+
+  gather: gatherConfig({
+    namespace: "pgFulltextFilter",
+    initialState: (): State => ({
+      tsqueryCodec: null,
+      tsqueryArrayCodec: null,
+      tsvectorCodec: null,
+      tsvectorArrayCodec: null,
+    }),
+    helpers: {
+      getTsvectorCodec(info) {
+        const { EXPORTABLE } = info;
+        if (!info.state.tsvectorCodec) {
+          info.state.tsvectorCodec = EXPORTABLE(
+            (sql) => ({
+              name: "tsvector",
+              sqlType: sql`tsvector`,
+              toPg(str) {
+                return str;
+              },
+              fromPg(str) {
+                return str;
+              },
+              executor: null,
+              attributes: undefined,
+              extensions: {
+                pg: {
+                  name: "tsvector",
+                  schemaName: "pg_catalog",
+                  // TODO: remove this
+                  serviceName: "",
+                },
+              },
+            }),
+            [sql],
+          );
+        }
+        return info.state.tsvectorCodec;
+      },
+      getTsvectorArrayCodec(info) {
+        const { EXPORTABLE } = info;
+        if (!info.state.tsvectorArrayCodec) {
+          const tsvectorCodec =
+            info.helpers.pgFulltextFilter.getTsvectorCodec();
+          info.state.tsvectorArrayCodec = EXPORTABLE(
+            (listOfCodec, tsvectorCodec) => listOfCodec(tsvectorCodec),
+            [listOfCodec, tsvectorCodec],
+          );
+        }
+        return info.state.tsvectorArrayCodec;
+      },
+      getTsqueryCodec(info) {
+        const { EXPORTABLE } = info;
+        if (!info.state.tsqueryCodec) {
+          info.state.tsqueryCodec = EXPORTABLE(
+            (sql) => ({
+              name: "tsquery",
+              sqlType: sql`tsquery`,
+              toPg(str) {
+                return str;
+              },
+              fromPg(str) {
+                return str;
+              },
+              executor: null,
+              attributes: undefined,
+              extensions: {
+                pg: {
+                  name: "tsquery",
+                  schemaName: "pg_catalog",
+                  // TODO: remove this
+                  serviceName: "",
+                },
+              },
+            }),
+            [sql],
+          );
+        }
+        return info.state.tsqueryCodec;
+      },
+      getTsqueryArrayCodec(info) {
+        const { EXPORTABLE } = info;
+        if (!info.state.tsqueryArrayCodec) {
+          const tsqueryCodec = info.helpers.pgFulltextFilter.getTsqueryCodec();
+          info.state.tsqueryArrayCodec = EXPORTABLE(
+            (listOfCodec, tsqueryCodec) => listOfCodec(tsqueryCodec),
+            [listOfCodec, tsqueryCodec],
+          );
+        }
+        return info.state.tsqueryArrayCodec;
+      },
+    },
+    hooks: {
+      async pgCodecs_findPgCodec(info, event) {
+        // If another plugin has already supplied a codec; skip
+        if (event.pgCodec) return;
+
+        const { pgType } = event;
+
+        if (
+          pgType.typname === "tsquery" &&
+          pgType.getNamespace()?.nspname === "pg_catalog"
+        ) {
+          event.pgCodec = info.helpers.pgFulltextFilter.getTsqueryCodec();
+        } else if (
+          pgType.typname === "_tsquery" &&
+          pgType.getNamespace()?.nspname === "pg_catalog"
+        ) {
+          event.pgCodec = info.helpers.pgFulltextFilter.getTsqueryArrayCodec();
+        }
+
+        if (
+          pgType.typname === "tsvector" &&
+          pgType.getNamespace()?.nspname === "pg_catalog"
+        ) {
+          event.pgCodec = info.helpers.pgFulltextFilter.getTsvectorCodec();
+        } else if (
+          pgType.typname === "_tsvector" &&
+          pgType.getNamespace()?.nspname === "pg_catalog"
+        ) {
+          event.pgCodec = info.helpers.pgFulltextFilter.getTsvectorArrayCodec();
+        }
+      },
+    },
+  }),
+
+  schema: {
+    hooks: {
+      init(_, build) {
+        const {
+          addConnectionFilterOperator,
+          sql,
+          graphql: { GraphQLString, Kind },
+          grafast: { lambda },
+          dataplanPg: { TYPES },
+          inflection,
+        } = build;
+
+        if (!(addConnectionFilterOperator instanceof Function)) {
+          throw new Error(
+            "PostGraphileFulltextFilterPlugin requires PostGraphileConnectionFilterPlugin to be loaded before it.",
+          );
+        }
+
+        const fullTextScalarName = inflection.fullTextScalarTypeName();
+        build.registerScalarType(
+          fullTextScalarName,
+          {},
+          () => ({
+            serialize(value) {
+              return String(value);
+            },
+            parseValue(value) {
+              if (typeof value === "string") {
+                return tsquery.parse(value) || "";
+              } else {
+                throw new Error(`${fullTextScalarName} must be a string`);
+              }
+            },
+            parseLiteral(lit) {
+              if (lit.kind === Kind.NULL) return null;
+              if (lit.kind !== Kind.STRING) {
+                throw new Error(`${fullTextScalarName} must be a string`);
+              }
+              return tsquery.parse(lit.value) || "";
+            },
+          }),
+          "Adding full text scalar type",
+        );
+
+        const tsvectorCodecs = [...build.allPgCodecs].filter(isTsvectorCodec);
+
+        for (const tsvectorCodec of tsvectorCodecs) {
+          build.setGraphQLTypeForPgCodec(
+            tsvectorCodec,
+            ["input", "output"],
+            fullTextScalarName,
+          );
+        }
+
+        const tsQueryScalarName = inflection.tsqueryScalarTypeName();
+
+        const tsqueryCodecs = [...build.allPgCodecs].filter(isTsQueryCodec);
+
+        for (const tsqueryCodec of tsqueryCodecs) {
+          build.setGraphQLTypeForPgCodec(
+            tsqueryCodec,
+            ["input", "output"],
+            tsQueryScalarName,
+          );
+        }
+
+        addConnectionFilterOperator(tsQueryScalarName, "matches", {
+          description: "Performs a full text search on the field.",
+          resolveType: () => GraphQLString,
+          resolve(
+            sqlIdentifier,
+            _sqlValue,
+            $input,
+            $placeholderable,
+            { fieldName },
+          ) {
+            const sqlValue = $placeholderable.placeholder($input, TYPES.text);
+            const $s = getHackedStep(build, $placeholderable as any);
+            if ($s) {
+              /* DO NOT DO THIS */
+              $s.__fts_ranks![fieldName!] = [sqlIdentifier, sqlValue];
+            }
+
+            return sql.query`${sqlIdentifier} @@ to_tsquery(${sqlValue})`;
+          },
+        });
+
+        return _;
+      },
+
+      GraphQLObjectType_fields(fields, build, context) {
+        const {
+          dataplanPg: { TYPES },
+          grafast: { constant },
+          graphql: { GraphQLFloat },
+          input: { pgRegistry },
+          sql,
+          inflection,
+          behavior,
+        } = build;
+
+        const {
+          scope: {
+            isPgClassType, // isPgRowType, isPgCompoundType,
+            pgCodec: rawPgCodec,
+          },
+          fieldWithHooks,
+        } = context;
+
+        if (!isPgClassType || !rawPgCodec?.attributes) {
+          return fields;
+        }
+
+        const codec = rawPgCodec as PgCodecWithAttributes;
+
+        function addTsvField(
+          baseFieldName: string,
+          fieldName: string,
+          origin: string,
+        ) {
+          build.extend(
+            fields,
+            {
+              [fieldName]: fieldWithHooks(
+                {
+                  fieldName,
+                  isPgTSVRankField: true,
+                },
+                () => {
+                  return {
+                    description: `Full-text search ranking when filtered by \`${baseFieldName}\`.`,
+                    type: GraphQLFloat,
+                    plan($step) {
+                      const $row = $step as PgSelectSingleStep;
+                      const $select = getHackedStep(build, $row);
+                      const hack = $select?.__fts_ranks[baseFieldName];
+                      if (!hack) {
+                        return constant(null);
+                      }
+                      const [identifier, tsQueryString] = hack;
+                      return $row.select(
+                        sql.fragment`ts_rank(${identifier}, to_tsquery(${tsQueryString}))`,
+                        TYPES.float,
+                      );
+                    },
+                  };
+                },
+              ),
+            },
+            origin,
+          );
+        }
+
+        for (const [attributeName, attribute] of Object.entries(
+          codec.attributes,
+        )) {
+          if (!isTsvectorCodec(attribute.codec)) continue;
+          if (
+            !behavior.pgCodecAttributeMatches(
+              [codec, attributeName],
+              "attribute:filterBy",
+            )
+          ) {
+            continue;
+          }
+
+          const baseFieldName = inflection.attribute({ codec, attributeName });
+          const fieldName = inflection.pgTsvRank(baseFieldName);
+          addTsvField(
+            baseFieldName,
+            fieldName,
+            `Adding rank field for ${attributeName}`,
+          );
+        }
+
+        const tsvProcs = Object.values(pgRegistry.pgResources).filter(
+          (r): r is PgResource<any, any, any, PgResourceParameter[], any> => {
+            if (!isTsvectorCodec(r.codec)) return false;
+            if (!r.parameters) return false;
+            if (!r.parameters[0]) return false;
+            if (r.parameters[0].codec !== codec) return false;
+            if (!behavior.pgResourceMatches(r, "typeField")) return false;
+            if (!behavior.pgResourceMatches(r, "proc:filterBy")) return false;
+            if (typeof r.from !== "function") return false;
+
+            // Must have only one required argument
+            // if (r.parameters.slice(1).some((p) => p.required)) return false
+
+            return true;
+          },
+        );
+
+        for (const resource of tsvProcs) {
+          const baseFieldName = inflection.computedAttributeField({ resource });
+          const fieldName = inflection.pgTsvRank(baseFieldName);
+          addTsvField(
+            baseFieldName,
+            fieldName,
+            `Adding rank field for computed column ${resource.name} on ${context.Self.name}`,
+          );
+        }
+
+        return fields;
+      },
+
+      GraphQLEnumType_values(values, build, context) {
+        const {
+          sql,
+          inflection,
+          input: { pgRegistry },
+          behavior,
+          dataplanPg: { TYPES },
+        } = build;
+
+        const {
+          scope: { isPgRowSortEnum, pgCodec: rawPgCodec },
+        } = context;
+
+        if (!isPgRowSortEnum || !rawPgCodec || !rawPgCodec.attributes) {
+          return values;
+        }
+
+        const codec = rawPgCodec as PgCodecWithAttributes;
+
+        const makePlan =
+          (fieldName: string, direction: "ASC" | "DESC") =>
+          (step: PgSelectStep) => {
+            const $select = getHackedStep(build, step);
+            const hack = $select?.__fts_ranks[fieldName];
+            if (hack) {
+              const [identifier, tsQueryString] = hack;
+              step.orderBy({
+                codec: TYPES.float,
+                fragment: sql.fragment`ts_rank(${identifier}, to_tsquery(${tsQueryString}))`,
+                direction,
+              });
+            }
+          };
+
+        const makeSpec = (fieldName: string, direction: "ASC" | "DESC") => ({
+          extensions: {
+            grafast: {
+              applyPlan: makePlan(fieldName, direction),
+            },
+          },
+        });
+
+        for (const [attributeName, attribute] of Object.entries(
+          codec.attributes,
+        )) {
+          if (!isTsvectorCodec(attribute.codec)) continue;
+          if (
+            !behavior.pgCodecAttributeMatches(
+              [codec, attributeName],
+              "attribute:filterBy",
+            )
+          ) {
+            continue;
+          }
+
+          const fieldName = inflection.attribute({ codec, attributeName });
+          const ascFieldName = inflection.pgTsvOrderByColumnRankEnum(
+            codec,
+            attributeName,
+            true,
+          );
+          const descFieldName = inflection.pgTsvOrderByColumnRankEnum(
+            codec,
+            attributeName,
+            false,
+          );
+
+          build.extend(
+            values,
+            {
+              [ascFieldName]: makeSpec(fieldName, "ASC"),
+              [descFieldName]: makeSpec(fieldName, "DESC"),
+            },
+            `Adding orders for rank of ${attributeName} on ${context.Self.name}`,
+          );
+        }
+
+        const tsvProcs = Object.values(pgRegistry.pgResources).filter(
+          (r): r is PgResource<any, any, any, PgResourceParameter[], any> => {
+            if (!isTsvectorCodec(r.codec)) return false;
+            if (!r.parameters) return false;
+            if (!r.parameters[0]) return false;
+            if (r.parameters[0].codec !== codec) return false;
+            if (!behavior.pgResourceMatches(r, "typeField")) return false;
+            if (!behavior.pgResourceMatches(r, "orderBy")) return false;
+            if (typeof r.from !== "function") return false;
+
+            // Must have only one required argument
+            // if (r.parameters.slice(1).some((p) => p.required)) return false
+
+            return true;
+          },
+        );
+
+        for (const resource of tsvProcs) {
+          const fieldName = inflection.computedAttributeField({
+            resource,
+          });
+          const ascFieldName = inflection.pgTsvOrderByComputedColumnRankEnum(
+            codec,
+            resource,
+            true,
+          );
+          const descFieldName = inflection.pgTsvOrderByComputedColumnRankEnum(
+            codec,
+            resource,
+            false,
+          );
+
+          build.extend(
+            values,
+            {
+              [ascFieldName]: makeSpec(fieldName, "ASC"),
+              [descFieldName]: makeSpec(fieldName, "DESC"),
+            },
+            `Adding TSV rank columns for sorting on table '${codec.name}'`,
+          );
+        }
+        return values;
+      },
+    },
+  },
+};
+
+export default PostGraphileFulltextFilterPlugin;


### PR DESCRIPTION
Here I added a test, to the end of the test file. Locally I use able to find out that `id0` has an type `::tsvector` which will break, because it's actually `::tsquery`. There is also a `index.tsquery.txt` with an unsuccessful attempt to fix the issue.

Here is he commit

https://github.com/hos/postgraphile-plugin-fulltext-filter/commit/328fa34485a2e61c4f96c15ae68bc638f6d6f8a5